### PR TITLE
Fixed RAMD stopping condition

### DIFF
--- a/openmm_ramd/openmm_ramd.py
+++ b/openmm_ramd/openmm_ramd.py
@@ -269,7 +269,7 @@ class RAMDSimulation(openmm_app.Simulation):
         
         self.counter += self.ramdSteps
         self.old_lig_com = lig_com
-        return lig_com
+        return lig_com, rec_com
     
     def run_RAMD_sim(self, max_num_steps=1e8):
         self.counter = 0
@@ -277,12 +277,12 @@ class RAMDSimulation(openmm_app.Simulation):
         
         # Do the simulation steps and loop here. These are done every step
         while self.counter < max_num_steps:
-            lig_com = self.RAMD_step(self.ramdSteps)
-            lig_prot_com_distance = np.linalg.norm(lig_com - start_lig_com)
+            lig_com, rec_com = self.RAMD_step(self.ramdSteps)
+            lig_prot_com_distance = np.linalg.norm(lig_com.value_in_unit(unit.angstroms) - rec_com.value_in_unit(unit.angstroms))
             if lig_prot_com_distance > self.maxDist:
                 self.max_distance_exceeded(self.counter)
                 break
-        
+
         return self.counter
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Fixes a unit mismatch and an incorrect distance metric in the RAMD exit criterion inside `run_RAMD_sim`.

Previously the loop computed `np.linalg.norm(lig_com - start_lig_com)` and compared it to `self.maxDist`. Two problems with that:

1. **Units.** `lig_com` is an OpenMM `Quantity` in nanometers, while `self.maxDist` is a bare number in angstroms (matching the convention used by `rMinRamd` and the rest of the class, which all go through `.value_in_unit(unit.angstroms)` before comparison). The comparison was off by a factor of 10, so the exit criterion did not fire at its intended threshold.
2. **Wrong distance.** Despite being named `lig_prot_com_distance`, the expression computed ligand displacement from the initial ligand position, not ligand–receptor COM distance.

This PR changes `RAMD_step` to also return the receptor COM, and updates `run_RAMD_sim` to compute the true ligand–receptor COM distance in angstroms.

## Todos

## Questions
1. Is `maxDist` definitely intended to be in angstroms? Inferred from the rest of the class, but worth confirming.
2. Is it necessary to handle the case when `receptor_atom_indices` is `None`?

## Status
- [ ] Ready to go