### PR TITLE
Feat: ramping and continue_until_unbound options

### DIFF
--- a/openmm_ramd/logger.py
+++ b/openmm_ramd/logger.py
@@ -27,7 +27,7 @@ class RAMD_logger():
         full_string = prefix + string + "\n"
         self.file.write(full_string)
         if print_also:
-            print("full_string")
+            print(full_string)
         return
     
     def exit_log(self, string, print_also=False):

--- a/openmm_ramd/openmm_ramd.py
+++ b/openmm_ramd/openmm_ramd.py
@@ -297,11 +297,11 @@ class RAMDSimulation(openmm_app.Simulation):
             #steps_between_force_updates = 50000  # e.g., 100/200 ps with 2/4 fs timestep
             # start with 25000 steps (100 ps at 4 fs timestep) to randomize initial state
             # then run ramd of the other forces at increasingly larger step counts
-            # go up up to 2 ns (500_000 steps at 4 fs timestep)
+            # go up to 4 ns (1_000_000 steps at 4 fs timestep)
             # use same n elements as in force schedule
             num_forces = len(force_schedule)
             steps_between_force_updates = np.concatenate(([25000], 
-                                            np.linspace(50_000, 2_000_000, num_forces - 1, dtype=int)))
+                                            np.linspace(50_000, 1_000_000, num_forces - 1, dtype=int)))
             self.logger.log(f"Ramping RAMD force magnitude: {force_schedule} kcal/mol*Angstrom " +
                             f"with {steps_between_force_updates} steps between updates.")
 

--- a/openmm_ramd/openmm_ramd.py
+++ b/openmm_ramd/openmm_ramd.py
@@ -271,7 +271,8 @@ class RAMDSimulation(openmm_app.Simulation):
         self.old_lig_com = lig_com
         return lig_com
     
-    def run_RAMD_sim(self, max_num_steps=1e8, ramping=False):
+    def run_RAMD_sim(self, max_num_steps=1e8, ramping=False, continue_until_unbound=False,
+                     extra_force=2.0, extra_steps=500_000):
         """
         Run the RAMD simulation until the maximum distance is exceeded.
 
@@ -282,6 +283,17 @@ class RAMDSimulation(openmm_app.Simulation):
         ramping : bool
             Whether to ramp up the RAMD force magnitude over time.
             Starts with no force and increases linearly to the target.
+        continue_until_unbound : bool
+            Whether to continue the simulation until the ligand is unbound,
+            even if the maximum number of steps is reached.
+            Will continue for extra_steps additional steps at an extra extra_force kcal/mol*Angstrom.
+            This repeats with increasing force until unbound.
+        extra_force : float
+            The extra force magnitude to add when continuing after max steps.
+            Default is 2.0 kcal/mol*Angstrom.
+        extra_steps : int
+            The number of extra steps to run when continuing after max steps.
+            Default is 500,000 steps (2 ns at 4 fs timestep).
         """
         self.counter = 0
         start_lig_com = self.RAMD_start()
@@ -334,8 +346,34 @@ class RAMDSimulation(openmm_app.Simulation):
             # break if max distance exceeded
             if lig_prot_com_distance > self.maxDist:
                 self.max_distance_exceeded(self.counter)
-                break
+                return self.counter
         
+        # if continue_until_unbound is set, continue with extra force if max steps reached
+        if continue_until_unbound:
+            while True:
+                # increase max_num_steps by extra_steps
+                max_num_steps += extra_steps
+                # set new increased force magnitude
+                ramd_force_magnitude = self.force_handler.random_force_magnitude.value_in_unit(
+                    kcal_per_mole_per_angstrom) + extra_force
+                self.logger.log(f"WARNING: Maximum number of steps increased to {max_num_steps}. " +
+                                f"Continuing RAMD simulation with extra force " +
+                                f"of {extra_force} kcal/mol*Angstrom for {extra_steps} extra steps. " +
+                                f"Total force magnitude of {ramd_force_magnitude} kcal/mol*Angstrom.",
+                                print_also=True)
+                self.force_handler.random_force_magnitude = ramd_force_magnitude * kcal_per_mole_per_angstrom
+                self.recompute_RAMD_force()
+                
+                # run additional steps with increased force
+                while self.counter < max_num_steps:
+                    lig_com = self.RAMD_step(self.ramdSteps)
+                    lig_prot_com_distance = np.linalg.norm(lig_com - start_lig_com)
+                    # break if max distance exceeded
+                    if lig_prot_com_distance > self.maxDist:
+                        self.max_distance_exceeded(self.counter)
+                        return self.counter
+
+        # return the total number of steps performed
         return self.counter
 
 if __name__ == "__main__":

--- a/openmm_ramd/openmm_ramd.py
+++ b/openmm_ramd/openmm_ramd.py
@@ -335,14 +335,14 @@ class RAMDSimulation(openmm_app.Simulation):
                 # starts at 0 steps
                 next_n_steps = self.counter + n_steps
                 # run regular RAMD simulation until next force update
-                self.main_ramd_loop(next_n_steps, start_lig_com)
+                self.main_ramd_loop(next_n_steps)
 
                 self.logger.log(f"Ramped RAMD force magnitude to {force} kcal/mol*Angstrom at step {self.counter}.")
             self.logger.log("Completed RAMD force ramping.")
                 
         # Do the standard RAMD simulation steps and loop here. These are done every step
         # by default 0.1/0.2 ps or 50 steps with 2/4 fs timestep before potential force update
-        self.main_ramd_loop(max_num_steps, start_lig_com)
+        self.main_ramd_loop(max_num_steps)
         
         # if continue_until_unbound is set, continue with extra force if max steps reached
         if continue_until_unbound:
@@ -361,7 +361,7 @@ class RAMDSimulation(openmm_app.Simulation):
                 self.recompute_RAMD_force()
                 
                 # run additional steps with increased force
-                self.main_ramd_loop(max_num_steps, start_lig_com)
+                self.main_ramd_loop(max_num_steps)
 
         # return the total number of steps performed
         return self.counter

--- a/openmm_ramd/openmm_ramd.py
+++ b/openmm_ramd/openmm_ramd.py
@@ -292,16 +292,15 @@ class RAMDSimulation(openmm_app.Simulation):
             max_force_magnitude = self.force_handler.random_force_magnitude.value_in_unit(
                 kcal_per_mole_per_angstrom)
             # start schedule at 0 force and then go up in steps of 2 from 1/2 max force
-            force_schedule = np.concatenate(([0], np.arange(max_force_magnitude/2, max_force_magnitude, 2.0), 
-                                             [max_force_magnitude]))
+            force_schedule = np.concatenate(([0], np.arange(max_force_magnitude/2, max_force_magnitude, 2.0)))
             #steps_between_force_updates = 50000  # e.g., 100/200 ps with 2/4 fs timestep
             # start with 25000 steps (100 ps at 4 fs timestep) to randomize initial state
             # then run ramd of the other forces at increasingly larger step counts
-            # go up to 4 ns (1_000_000 steps at 4 fs timestep)
+            # go up from 0.5 ns to 4 ns (125_000 to 1_000_000 steps at 4 fs timestep)
             # use same n elements as in force schedule
             num_forces = len(force_schedule)
-            steps_between_force_updates = np.concatenate(([25000], 
-                                            np.linspace(50_000, 1_000_000, num_forces - 1, dtype=int)))
+            steps_between_force_updates = np.concatenate(([25_000], 
+                                            np.linspace(125_000, 1_000_000, num_forces - 1, dtype=int)))
             self.logger.log(f"Ramping RAMD force magnitude: {force_schedule} kcal/mol*Angstrom " +
                             f"with {steps_between_force_updates} steps between updates.")
 

--- a/openmm_ramd/openmm_ramd.py
+++ b/openmm_ramd/openmm_ramd.py
@@ -271,6 +271,16 @@ class RAMDSimulation(openmm_app.Simulation):
         self.old_lig_com = lig_com
         return lig_com
     
+    def main_ramd_loop(self, max_num_steps, start_lig_com):
+        while self.counter < max_num_steps:
+            # by default 0.1/0.2 ps or 50 steps with 2/4 fs timestep before potential force update
+            lig_com = self.RAMD_step(self.ramdSteps)
+            lig_prot_com_distance = np.linalg.norm(lig_com - start_lig_com)
+            # break if max distance exceeded
+            if lig_prot_com_distance > self.maxDist:
+                self.max_distance_exceeded(self.counter)
+                return self.counter
+
     def run_RAMD_sim(self, max_num_steps=1e8, ramping=False, continue_until_unbound=False,
                      extra_force=2.0, extra_steps=500_000):
         """
@@ -305,7 +315,7 @@ class RAMDSimulation(openmm_app.Simulation):
                 kcal_per_mole_per_angstrom)
             # start schedule at 0 force and then go up in steps of 2 from 1/2 max force
             force_schedule = np.concatenate(([0], np.arange(max_force_magnitude/2, max_force_magnitude, 2.0)))
-            #steps_between_force_updates = 50000  # e.g., 100/200 ps with 2/4 fs timestep
+            # steps_between_force_updates = 50000  # e.g., 100/200 ps with 2/4 fs timestep
             # start with 25000 steps (100 ps at 4 fs timestep) to randomize initial state
             # then run ramd of the other forces at increasingly larger step counts
             # go up from 0.5 ns to 4 ns (125_000 to 1_000_000 steps at 4 fs timestep)
@@ -326,27 +336,14 @@ class RAMDSimulation(openmm_app.Simulation):
                 # starts at 0 steps
                 next_n_steps = self.counter + n_steps
                 # run regular RAMD simulation until next force update
-                while self.counter < next_n_steps:
-                    # take MD steps here
-                    lig_com = self.RAMD_step(self.ramdSteps)
-                    lig_prot_com_distance = np.linalg.norm(lig_com - start_lig_com)
-                    
-                    # break if max distance exceeded early    
-                    if lig_prot_com_distance > self.maxDist:
-                        self.max_distance_exceeded(self.counter)
-                        return self.counter
+                self.main_ramd_loop(next_n_steps, start_lig_com)
+
                 self.logger.log(f"Ramped RAMD force magnitude to {force} kcal/mol*Angstrom at step {self.counter}.")
             self.logger.log("Completed RAMD force ramping.")
                 
         # Do the standard RAMD simulation steps and loop here. These are done every step
-        while self.counter < max_num_steps:
-            # by default 0.1/0.2 ps or 50 steps with 2/4 fs timestep before potential force update
-            lig_com = self.RAMD_step(self.ramdSteps)
-            lig_prot_com_distance = np.linalg.norm(lig_com - start_lig_com)
-            # break if max distance exceeded
-            if lig_prot_com_distance > self.maxDist:
-                self.max_distance_exceeded(self.counter)
-                return self.counter
+        # by default 0.1/0.2 ps or 50 steps with 2/4 fs timestep before potential force update
+        self.main_ramd_loop(max_num_steps, start_lig_com)
         
         # if continue_until_unbound is set, continue with extra force if max steps reached
         if continue_until_unbound:
@@ -365,13 +362,7 @@ class RAMDSimulation(openmm_app.Simulation):
                 self.recompute_RAMD_force()
                 
                 # run additional steps with increased force
-                while self.counter < max_num_steps:
-                    lig_com = self.RAMD_step(self.ramdSteps)
-                    lig_prot_com_distance = np.linalg.norm(lig_com - start_lig_com)
-                    # break if max distance exceeded
-                    if lig_prot_com_distance > self.maxDist:
-                        self.max_distance_exceeded(self.counter)
-                        return self.counter
+                self.main_ramd_loop(max_num_steps, start_lig_com)
 
         # return the total number of steps performed
         return self.counter

--- a/openmm_ramd/openmm_ramd.py
+++ b/openmm_ramd/openmm_ramd.py
@@ -322,7 +322,7 @@ class RAMDSimulation(openmm_app.Simulation):
                     # break if max distance exceeded early    
                     if lig_prot_com_distance > self.maxDist:
                         self.max_distance_exceeded(self.counter)
-                        break
+                        return self.counter
                 self.logger.log(f"Ramped RAMD force magnitude to {force} kcal/mol*Angstrom at step {self.counter}.")
             self.logger.log("Completed RAMD force ramping.")
                 


### PR DESCRIPTION
## Description
Optional args for an initial ramping period for RAMD runs and for a `continue_until_unbound`, where RAMD will continue with stronger and stronger (can be set as args) force.

Original simulation scripts and setup should be maintained, these new options default to `False`.

I implemented these for my own simulations/project, so not extremely thoroughly tested but thought it might be useful nonetheless.

If you're not interested in these options, feel free to close ~

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go